### PR TITLE
cb_gcloud

### DIFF
--- a/src/auth/authutils.py
+++ b/src/auth/authutils.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import socket
 
 from passlib.handlers.argon2 import argon2
 
@@ -14,8 +15,9 @@ def verify_hash(secret: str, pw_hash: str) -> bool:
     return argon2.verify(secret, pw_hash)
 
 
-def verify_hosts(remote_host: str, host_list: list[str]) -> bool:
-    return "*" in host_list or remote_host in host_list
+def verify_hosts(remote_ip: str, host_list: list[str]) -> bool:
+    ip_list: list[str] = [socket.gethostbyname(host) for host in host_list]
+    return "*" in host_list or remote_ip in host_list
 
 
 class Scopes(str, Enum):

--- a/src/auth/authutils.py
+++ b/src/auth/authutils.py
@@ -1,8 +1,10 @@
+import logging
 from enum import Enum
 import socket
 
 from passlib.handlers.argon2 import argon2
 
+from basic_log import log
 from config import server_conf
 
 
@@ -17,7 +19,9 @@ def verify_hash(secret: str, pw_hash: str) -> bool:
 
 def verify_hosts(remote_ip: str, host_list: list[str]) -> bool:
     ip_list: list[str] = [socket.gethostbyname(host) for host in host_list]
-    return "*" in host_list or remote_ip in host_list
+    log(f"hosts: {host_list}", logging.DEBUG)
+    log(f"ips: {ip_list}", logging.DEBUG)
+    return "*" in host_list or remote_ip in ip_list
 
 
 class Scopes(str, Enum):

--- a/src/blueprints/sse.py
+++ b/src/blueprints/sse.py
@@ -1,0 +1,71 @@
+import json
+import logging
+from asyncio import sleep
+from dataclasses import dataclass
+from typing import Optional
+
+from discord import Message
+from quart import Blueprint, abort, make_response, request, g
+
+from auth import UserModel
+from auth.authutils import Scopes
+from basic_log import log
+from decorators import apikey_required
+from discord_utils import DiscommentClient
+from msg_queue import channel_msg_manager
+
+sse: Blueprint = Blueprint("sse", __name__)
+
+
+@dataclass
+class ServerSentEvent:
+    data: str
+    retry: int | None
+    event: str | None = None
+    id: int | None = None
+
+    def encode(self) -> bytes:
+        message = f"data: {self.data}"
+        if self.event is not None:
+            message = f"{message}\nevent: {self.event}"
+        if self.id is not None:
+            message = f"{message}\nid: {self.id}"
+        if self.retry is not None:
+            message = f"{message}\nretry: {self.retry}"
+        message = f"{message}\r\n\r\n"
+        return message.encode('utf-8')
+
+
+@sse.get("/sse/comments")
+@apikey_required(scopes=[Scopes.ACCOUNT_READ])
+async def sse_comments():
+    if "text/event-stream" not in request.accept_mimetypes:
+        abort(400)
+
+    user: UserModel = g.get("user")
+    channel_id: int = int(request.args["channelId"])
+
+    async def send_events():
+        msgs: list = channel_msg_manager.pop(channel_id=channel_id)
+        last_msg: Optional[Message] = msgs[-1] if 0 < len(msgs) else None
+
+        while True:
+            log("sse alive", logging.DEBUG, __name__)
+            await sleep(user.user_data.websocket_sleep_s)
+            last_msg = msgs[-1] if 0 < len(msgs) else last_msg
+            log(last_msg.content if last_msg is not None else "None", logging.DEBUG, __name__)
+            msgs = channel_msg_manager.pop(channel_id=channel_id, as_of=last_msg)
+
+            event = ServerSentEvent(json.dumps([DiscommentClient.msg_to_json(m) for m in msgs]), retry=3)
+            yield event.encode()
+
+    response = await make_response(
+        send_events(),
+        {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            'Transfer-Encoding': 'chunked',
+        },
+    )
+    response.timeout = None
+    return response

--- a/src/blueprints/sse.py
+++ b/src/blueprints/sse.py
@@ -45,13 +45,15 @@ async def sse_comments():
     user: UserModel = g.get("user")
     channel_id: int = int(request.args["channelId"])
 
+    sleep_time: int = user.user_data.websocket_sleep_s
+
     async def send_events():
         msgs: list = channel_msg_manager.pop(channel_id=channel_id)
         last_msg: Optional[Message] = msgs[-1] if 0 < len(msgs) else None
 
         while True:
             log("sse alive", logging.DEBUG, __name__)
-            await sleep(user.user_data.websocket_sleep_s)
+            await sleep(sleep_time)
             last_msg = msgs[-1] if 0 < len(msgs) else last_msg
             log(last_msg.content if last_msg is not None else "None", logging.DEBUG, __name__)
             msgs = channel_msg_manager.pop(channel_id=channel_id, as_of=last_msg)

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -1,4 +1,5 @@
 # https://stackoverflow.com/questions/71260887/how-to-use-api-key-authentication-with-quart-api
+import logging
 from functools import wraps
 from typing import Callable, Any
 
@@ -8,6 +9,7 @@ from werkzeug.exceptions import Unauthorized, Forbidden
 
 from auth import auth_store, UserModel
 from auth.authutils import create_hash, verify_hash, verify_hosts, verify_scopes, Scopes
+from basic_log import log
 from sqlite import GenericQuery
 
 
@@ -59,6 +61,8 @@ def apikey_required(scopes: list[Scopes] = None) -> Callable:
                 raise Unauthorized("API Key not recognized")
 
             g.user = record
+
+            log(str(ctx.headers), logging.DEBUG)
 
             if not verify_hash(api_key, record.user_data.hash):
                 raise Forbidden("API Key not verified")

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from basic_log import log
 from blueprints.api import api
 from blueprints.jinja import jinja
+from blueprints.sse import sse
 from blueprints.websockets import ws
 from config import server_conf
 from discord_utils import discord_client
@@ -42,6 +43,7 @@ async def before_serving():
 
 app.register_blueprint(api)
 app.register_blueprint(ws)
+app.register_blueprint(sse)
 if server_conf.static_routes_enabled:
     app.register_blueprint(jinja)
 

--- a/src/templates/js/discomment.js
+++ b/src/templates/js/discomment.js
@@ -2,9 +2,23 @@ const host = "{{ host }}"
 const port = "{{ port }}"
 const apikey = "{{ apikey }}"
 const channelId = "{{ channelId }}"
-const ws = new WebSocket("ws://" + host + ":" + port + "/ws/comments?auth=" + apikey + "&channelId=" + channelId.toString());
+const baseUrl = host + ":" + port
+// const ws = new WebSocket("ws://" + host + ":" + port + "/ws/comments?auth=" + apikey + "&channelId=" + channelId.toString());
+//
+// ws.addEventListener("message", function (event) {
+//     let d = JSON.parse(event.data);
+//     for (let i = 0; i < d.length; i++) {
+//         let m = d[i]
+//         const li = document.createElement("li");
+//         li.appendChild(document.createTextNode(JSON.stringify(m)));
+//         document.getElementById("ul_messages").prepend(li);
+//     }
+// });
 
-ws.addEventListener("message", function (event) {
+let source = new EventSource("http://" + baseUrl + "/sse/comments?auth=" + apikey + "&channelId=" + channelId.toString());
+source.onmessage = function(event) {
+    console.log('Incoming data:' + event.data);
+
     let d = JSON.parse(event.data);
     for (let i = 0; i < d.length; i++) {
         let m = d[i]
@@ -12,7 +26,7 @@ ws.addEventListener("message", function (event) {
         li.appendChild(document.createTextNode(JSON.stringify(m)));
         document.getElementById("ul_messages").prepend(li);
     }
-});
+};
 
 function send(event) {
     const message = (new FormData(event.target)).get("inpt_message");


### PR DESCRIPTION
Commit Msg: getting things running in a gcp compute instance

- auth utils assumes IP addresses for the remote host, and converts allowed hostnames to IP addresses
- new Server Side Events version of the websockets endpoint, to support http/2 (TODO, unify logic for those, as websocket vs sse should just be an implementation detail at the endpoint level)
- comment out websocket implementation in static js, pending learning more about managing http/1.1 vs http/2